### PR TITLE
Remove small gear icon button from dashboard

### DIFF
--- a/frontend/src/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/components/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Settings, RefreshCw, Moon, Sun, Monitor, Wifi, WifiOff } from 'lucide-react'
+import { RefreshCw, Moon, Sun, Monitor, Wifi, WifiOff } from 'lucide-react'
 import { SystemStatus, HealthStatus, CacheStatistics } from '../../types/api'
 import StatusCard from '../StatusCard'
 import StatsGrid from '../StatsGrid'
@@ -178,13 +178,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ className }) => {
                 {getThemeIcon()}
               </button>
 
-              {/* Settings */}
-              <button
-                className="btn btn-ghost p-2"
-                aria-label="Settings"
-              >
-                <Settings className="w-4 h-4" />
-              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Remove redundant gear icon settings button from the dashboard header to streamline UI and avoid duplicate access points.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4912d07-d670-44be-b35a-cce03c7ffc92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b4912d07-d670-44be-b35a-cce03c7ffc92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

