### PR TITLE
Troubleshoot plex file size display permission issue

### DIFF
--- a/FILE_SIZE_FIX_SUMMARY.md
+++ b/FILE_SIZE_FIX_SUMMARY.md
@@ -1,0 +1,116 @@
+# File Size Issue Fix Summary
+
+## Problem Identified
+
+The test run was finding the correct media files from Plex but not showing file sizes. This was happening because:
+
+1. **Development Environment Issue**: In development/testing environments, the configured media paths (`/mediasource`, `/plexsource`, `/cache`, etc.) don't exist
+2. **Path Conversion Failure**: The `process_file_paths` method converts Plex paths to real system paths, but these paths don't exist in development
+3. **File Size Retrieval Failure**: The `analyze_files_for_test_mode` method was skipping files that don't exist, resulting in no file sizes being shown
+
+## Root Cause
+
+The issue was in `/workspace/src/core/file_operations.py` in the `analyze_files_for_test_mode` method (lines 290-313). When files didn't exist at the converted paths, the method would:
+- Log a warning about the file not existing
+- Skip the file entirely
+- Not include it in the analysis results
+
+This meant that in development environments, all files were being skipped, so no file sizes were shown.
+
+## Solution Implemented
+
+### 1. Development Mode Detection
+Added automatic detection of development environments by checking if configured media paths exist:
+
+```python
+def _detect_development_mode(self) -> bool:
+    """Detect if we're running in a development environment."""
+    # Check if the configured media paths exist
+    media_paths = [
+        self.config.paths.real_source,
+        self.config.paths.cache_destination,
+    ]
+    
+    if self.config.paths.additional_sources:
+        media_paths.extend(self.config.paths.additional_sources)
+    
+    # If none of the configured media paths exist, we're likely in development
+    existing_paths = 0
+    for path in media_paths:
+        if path and Path(path).exists():
+            existing_paths += 1
+    
+    is_dev = existing_paths == 0
+    if is_dev:
+        self.logger.info("Development mode detected - media paths not accessible")
+    
+    return is_dev
+```
+
+### 2. Enhanced File Analysis
+Modified `analyze_files_for_test_mode` to handle missing files gracefully:
+
+- **Development Mode**: Creates mock file entries with "Unknown (dev mode)" size for files that don't exist
+- **Production Mode**: Skips files that don't exist (original behavior)
+- **Permission Errors**: Still includes files but marks size as "Unknown (permission denied)"
+
+### 3. Better Logging
+Added informative logging to distinguish between development mode and actual permission issues:
+
+```python
+if self.is_development_mode:
+    self.logger.info(f"Test mode analysis: {files_analyzed} files with sizes, {files_skipped} files in development mode (paths not accessible)")
+else:
+    self.logger.info(f"Test mode analysis: {files_analyzed} files with sizes, {files_skipped} files skipped (permission issues)")
+```
+
+## Files Modified
+
+- `/workspace/src/core/file_operations.py`
+  - Added `_detect_development_mode()` method
+  - Enhanced `analyze_files_for_test_mode()` method
+  - Added development mode detection to `__init__`
+
+## Expected Behavior After Fix
+
+### In Development Environment:
+- Test runs will show files found from Plex API
+- File sizes will show as "Unknown (dev mode)" for files that don't exist locally
+- Logs will clearly indicate development mode
+- All files will be included in the analysis results
+
+### In Production Environment:
+- Test runs will show actual file sizes for accessible files
+- Files that don't exist will be skipped (original behavior)
+- Permission errors will be logged but files will still be included with "Unknown (permission denied)" size
+
+## Testing the Fix
+
+### In Development:
+1. Run a test operation
+2. Check that files are now shown in the results
+3. Verify that file sizes show as "Unknown (dev mode)"
+4. Check logs for "Development mode detected" message
+
+### In Production:
+1. Ensure media paths are properly mounted
+2. Run a test operation
+3. Verify that actual file sizes are shown
+4. Check that the fix doesn't break existing functionality
+
+## Safety Considerations
+
+- **No Breaking Changes**: The fix maintains backward compatibility
+- **Production Safety**: Production behavior is unchanged for existing files
+- **Permission Handling**: Still handles permission errors gracefully
+- **Plex Docker Compatibility**: No changes to file operations that could affect Plex Docker access
+
+## Additional Notes
+
+This fix addresses the immediate issue of file sizes not showing in test runs. For production environments, ensure that:
+
+1. Media paths are properly mounted in Docker containers
+2. File permissions allow the application to read media files
+3. Plex Docker container has appropriate access to the same paths
+
+The fix is designed to be safe and won't interfere with actual file operations or Plex Docker functionality.

--- a/debug_file_sizes.py
+++ b/debug_file_sizes.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Debug script to identify file size retrieval issues in test mode.
+
+This script helps diagnose why file sizes are not showing in test runs
+by checking file permissions, path accessibility, and testing the
+analyze_files_for_test_mode function.
+"""
+
+import os
+import sys
+import logging
+from pathlib import Path
+from typing import List, Dict, Any
+
+# Add src to path for imports
+sys.path.insert(0, '/workspace/src')
+
+try:
+    from config.settings import Config
+    from core.file_operations import FileOperations
+    from core.interfaces import TestModeAnalysis
+except ImportError as e:
+    print(f"Import error: {e}")
+    print("Make sure you're running this from the workspace root")
+    sys.exit(1)
+
+def setup_logging():
+    """Setup logging for debugging."""
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+    return logging.getLogger(__name__)
+
+def check_directory_permissions(path: str, logger: logging.Logger) -> Dict[str, Any]:
+    """Check directory permissions and accessibility."""
+    result = {
+        'path': path,
+        'exists': False,
+        'readable': False,
+        'writable': False,
+        'permissions': None,
+        'owner': None,
+        'group': None,
+        'error': None
+    }
+    
+    try:
+        path_obj = Path(path)
+        result['exists'] = path_obj.exists()
+        
+        if result['exists']:
+            stat_info = path_obj.stat()
+            result['permissions'] = oct(stat_info.st_mode)[-3:]
+            result['owner'] = stat_info.st_uid
+            result['group'] = stat_info.st_gid
+            
+            # Check readability
+            try:
+                list(path_obj.iterdir())
+                result['readable'] = True
+            except PermissionError:
+                result['readable'] = False
+                result['error'] = "Permission denied - cannot read directory"
+            
+            # Check writability
+            try:
+                test_file = path_obj / '.test_write'
+                test_file.touch()
+                test_file.unlink()
+                result['writable'] = True
+            except PermissionError:
+                result['writable'] = False
+                if not result['error']:
+                    result['error'] = "Permission denied - cannot write to directory"
+        else:
+            result['error'] = "Directory does not exist"
+            
+    except Exception as e:
+        result['error'] = str(e)
+    
+    return result
+
+def check_file_permissions(file_path: str, logger: logging.Logger) -> Dict[str, Any]:
+    """Check individual file permissions and size retrieval."""
+    result = {
+        'path': file_path,
+        'exists': False,
+        'readable': False,
+        'size_bytes': 0,
+        'size_readable': '0B',
+        'permissions': None,
+        'owner': None,
+        'group': None,
+        'error': None
+    }
+    
+    try:
+        path_obj = Path(file_path)
+        result['exists'] = path_obj.exists()
+        
+        if result['exists']:
+            stat_info = path_obj.stat()
+            result['permissions'] = oct(stat_info.st_mode)[-3:]
+            result['owner'] = stat_info.st_uid
+            result['group'] = stat_info.st_gid
+            
+            # Try to get file size
+            try:
+                result['size_bytes'] = stat_info.st_size
+                result['size_readable'] = format_file_size(result['size_bytes'])
+                result['readable'] = True
+            except (OSError, PermissionError) as e:
+                result['error'] = f"Cannot read file size: {e}"
+        else:
+            result['error'] = "File does not exist"
+            
+    except Exception as e:
+        result['error'] = str(e)
+    
+    return result
+
+def format_file_size(size_bytes: int) -> str:
+    """Format file size in human readable format."""
+    if size_bytes == 0:
+        return "0B"
+    
+    size_names = ["B", "KB", "MB", "GB", "TB"]
+    i = 0
+    size_float = float(size_bytes)
+    while size_float >= 1024 and i < len(size_names) - 1:
+        size_float /= 1024.0
+        i += 1
+    
+    return f"{size_float:.1f}{size_names[i]}"
+
+def test_analyze_files_for_test_mode(file_operations: FileOperations, test_files: List[str], logger: logging.Logger):
+    """Test the analyze_files_for_test_mode function."""
+    logger.info("Testing analyze_files_for_test_mode function...")
+    
+    try:
+        analysis = file_operations.analyze_files_for_test_mode(test_files, "cache")
+        
+        logger.info(f"Analysis results:")
+        logger.info(f"  Files processed: {analysis.file_count}")
+        logger.info(f"  Total size: {analysis.total_size_readable}")
+        logger.info(f"  Operation type: {analysis.operation_type}")
+        
+        if analysis.file_details:
+            logger.info("  File details:")
+            for detail in analysis.file_details[:5]:  # Show first 5
+                logger.info(f"    {detail.filename}: {detail.size_readable}")
+        else:
+            logger.warning("  No file details available - this indicates permission issues")
+            
+        return analysis
+        
+    except Exception as e:
+        logger.error(f"Error in analyze_files_for_test_mode: {e}")
+        return None
+
+def create_test_files(test_dir: str, logger: logging.Logger) -> List[str]:
+    """Create test files for testing."""
+    test_files = []
+    
+    try:
+        test_path = Path(test_dir)
+        test_path.mkdir(exist_ok=True)
+        
+        # Create some test files with different sizes
+        test_files_data = [
+            ("test1.mkv", 1024 * 1024),  # 1MB
+            ("test2.mp4", 5 * 1024 * 1024),  # 5MB
+            ("test3.avi", 10 * 1024 * 1024),  # 10MB
+        ]
+        
+        for filename, size in test_files_data:
+            file_path = test_path / filename
+            with open(file_path, 'wb') as f:
+                f.write(b'0' * size)
+            test_files.append(str(file_path))
+            logger.info(f"Created test file: {file_path} ({format_file_size(size)})")
+            
+    except Exception as e:
+        logger.error(f"Error creating test files: {e}")
+    
+    return test_files
+
+def main():
+    """Main diagnostic function."""
+    logger = setup_logging()
+    logger.info("Starting file size diagnostic...")
+    
+    # Load configuration
+    try:
+        config = Config()
+        logger.info("Configuration loaded successfully")
+    except Exception as e:
+        logger.error(f"Failed to load configuration: {e}")
+        return 1
+    
+    # Check configured paths
+    paths_to_check = [
+        config.paths.plex_source,
+        config.paths.real_source,
+        config.paths.cache_destination,
+    ]
+    
+    if config.paths.additional_sources:
+        paths_to_check.extend(config.paths.additional_sources)
+    
+    logger.info("Checking configured paths...")
+    for path in paths_to_check:
+        if path:
+            result = check_directory_permissions(path, logger)
+            logger.info(f"Path: {path}")
+            logger.info(f"  Exists: {result['exists']}")
+            logger.info(f"  Readable: {result['readable']}")
+            logger.info(f"  Writable: {result['writable']}")
+            logger.info(f"  Permissions: {result['permissions']}")
+            if result['error']:
+                logger.warning(f"  Error: {result['error']}")
+    
+    # Create test files in a writable location
+    test_dir = "/tmp/cacherr_test"
+    logger.info(f"Creating test files in {test_dir}...")
+    test_files = create_test_files(test_dir, logger)
+    
+    if not test_files:
+        logger.error("No test files created, cannot proceed with testing")
+        return 1
+    
+    # Test file operations
+    try:
+        file_operations = FileOperations(config)
+        logger.info("FileOperations initialized successfully")
+        
+        # Test analyze_files_for_test_mode
+        analysis = test_analyze_files_for_test_mode(file_operations, test_files, logger)
+        
+        if analysis and analysis.file_count > 0:
+            logger.info("✅ File size analysis is working correctly")
+        else:
+            logger.error("❌ File size analysis is not working - no files processed")
+            
+    except Exception as e:
+        logger.error(f"Error testing file operations: {e}")
+        return 1
+    
+    # Check individual test files
+    logger.info("Checking individual test files...")
+    for test_file in test_files:
+        result = check_file_permissions(test_file, logger)
+        logger.info(f"File: {test_file}")
+        logger.info(f"  Exists: {result['exists']}")
+        logger.info(f"  Readable: {result['readable']}")
+        logger.info(f"  Size: {result['size_readable']}")
+        logger.info(f"  Permissions: {result['permissions']}")
+        if result['error']:
+            logger.warning(f"  Error: {result['error']}")
+    
+    # Cleanup test files
+    try:
+        import shutil
+        shutil.rmtree(test_dir)
+        logger.info(f"Cleaned up test directory: {test_dir}")
+    except Exception as e:
+        logger.warning(f"Could not clean up test directory: {e}")
+    
+    logger.info("Diagnostic complete")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/simple_debug.py
+++ b/simple_debug.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Simple diagnostic script to check file permissions and paths.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+def format_file_size(size_bytes: int) -> str:
+    """Format file size in human readable format."""
+    if size_bytes == 0:
+        return "0B"
+    
+    size_names = ["B", "KB", "MB", "GB", "TB"]
+    i = 0
+    size_float = float(size_bytes)
+    while size_float >= 1024 and i < len(size_names) - 1:
+        size_float /= 1024.0
+        i += 1
+    
+    return f"{size_float:.1f}{size_names[i]}"
+
+def check_path(path: str):
+    """Check if a path exists and is accessible."""
+    print(f"\nChecking path: {path}")
+    
+    try:
+        path_obj = Path(path)
+        exists = path_obj.exists()
+        print(f"  Exists: {exists}")
+        
+        if exists:
+            try:
+                stat_info = path_obj.stat()
+                print(f"  Permissions: {oct(stat_info.st_mode)[-3:]}")
+                print(f"  Owner: {stat_info.st_uid}")
+                print(f"  Group: {stat_info.st_gid}")
+                
+                if path_obj.is_file():
+                    print(f"  Size: {format_file_size(stat_info.st_size)}")
+                elif path_obj.is_dir():
+                    try:
+                        files = list(path_obj.iterdir())
+                        print(f"  Directory contents: {len(files)} items")
+                        # Show first few files
+                        for i, item in enumerate(files[:3]):
+                            if item.is_file():
+                                try:
+                                    size = item.stat().st_size
+                                    print(f"    {item.name}: {format_file_size(size)}")
+                                except PermissionError:
+                                    print(f"    {item.name}: Permission denied")
+                            else:
+                                print(f"    {item.name}: [directory]")
+                    except PermissionError:
+                        print("  Cannot read directory contents: Permission denied")
+                        
+            except PermissionError:
+                print("  Permission denied")
+            except Exception as e:
+                print(f"  Error: {e}")
+        else:
+            print("  Path does not exist")
+            
+    except Exception as e:
+        print(f"  Error: {e}")
+
+def create_test_files():
+    """Create test files to verify file size functionality."""
+    test_dir = Path("/tmp/cacherr_test")
+    print(f"\nCreating test files in {test_dir}...")
+    
+    try:
+        test_dir.mkdir(exist_ok=True)
+        
+        # Create test files
+        test_files = [
+            ("test1.mkv", 1024 * 1024),  # 1MB
+            ("test2.mp4", 5 * 1024 * 1024),  # 5MB
+        ]
+        
+        created_files = []
+        for filename, size in test_files:
+            file_path = test_dir / filename
+            with open(file_path, 'wb') as f:
+                f.write(b'0' * size)
+            created_files.append(str(file_path))
+            print(f"  Created: {filename} ({format_file_size(size)})")
+        
+        return created_files
+        
+    except Exception as e:
+        print(f"  Error creating test files: {e}")
+        return []
+
+def test_file_size_retrieval(files):
+    """Test file size retrieval like the analyze_files_for_test_mode function."""
+    print(f"\nTesting file size retrieval for {len(files)} files...")
+    
+    total_size = 0
+    successful_files = 0
+    
+    for file_path in files:
+        try:
+            path_obj = Path(file_path)
+            if path_obj.exists():
+                stat_info = path_obj.stat()
+                file_size = stat_info.st_size
+                total_size += file_size
+                successful_files += 1
+                print(f"  ✅ {path_obj.name}: {format_file_size(file_size)}")
+            else:
+                print(f"  ❌ {file_path}: File does not exist")
+        except (OSError, PermissionError) as e:
+            print(f"  ❌ {file_path}: {e}")
+    
+    print(f"\nResults:")
+    print(f"  Files processed: {successful_files}/{len(files)}")
+    print(f"  Total size: {format_file_size(total_size)}")
+    
+    return successful_files > 0
+
+def main():
+    """Main diagnostic function."""
+    print("=== Cacherr File Size Diagnostic ===")
+    
+    # Check common paths that might be configured
+    paths_to_check = [
+        "/mediasource",
+        "/plexsource", 
+        "/cache",
+        "/config",
+        "/media",
+        "/mnt/user",
+        "/mnt/user0",
+    ]
+    
+    print("\n1. Checking configured paths...")
+    for path in paths_to_check:
+        check_path(path)
+    
+    # Create and test with local files
+    print("\n2. Testing file size functionality...")
+    test_files = create_test_files()
+    
+    if test_files:
+        success = test_file_size_retrieval(test_files)
+        
+        if success:
+            print("\n✅ File size retrieval is working correctly")
+        else:
+            print("\n❌ File size retrieval is not working")
+        
+        # Cleanup
+        try:
+            import shutil
+            shutil.rmtree("/tmp/cacherr_test")
+            print("\nCleaned up test files")
+        except Exception as e:
+            print(f"\nCould not clean up test files: {e}")
+    else:
+        print("\n❌ Could not create test files")
+    
+    print("\n=== Diagnostic Complete ===")
+
+if __name__ == "__main__":
+    main()

--- a/test_file_size_fix.py
+++ b/test_file_size_fix.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the file size fix works in development mode.
+"""
+
+import sys
+import os
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, '/workspace/src')
+
+def test_file_operations():
+    """Test the FileOperations class with the fix."""
+    try:
+        from config.settings import Config
+        from core.file_operations import FileOperations
+        from core.interfaces import TestModeAnalysis
+        
+        print("✅ Imports successful")
+        
+        # Load configuration
+        config = Config()
+        print("✅ Configuration loaded")
+        
+        # Initialize FileOperations
+        file_ops = FileOperations(config)
+        print(f"✅ FileOperations initialized (development mode: {file_ops.is_development_mode})")
+        
+        # Test with some mock file paths (that don't exist)
+        test_files = [
+            "/mediasource/Movies/Test Movie (2023)/Test Movie (2023).mkv",
+            "/mediasource/TV Shows/Test Show/Season 01/Test Show S01E01.mkv",
+            "/mediasource/Movies/Another Movie/Another Movie.mp4"
+        ]
+        
+        print(f"\nTesting with {len(test_files)} mock files...")
+        
+        # Test analyze_files_for_test_mode
+        analysis = file_ops.analyze_files_for_test_mode(test_files, "cache")
+        
+        print(f"\nResults:")
+        print(f"  Files processed: {analysis.file_count}")
+        print(f"  Total size: {analysis.total_size_readable}")
+        print(f"  Operation type: {analysis.operation_type}")
+        
+        if analysis.file_details:
+            print(f"\nFile details:")
+            for i, detail in enumerate(analysis.file_details[:3]):  # Show first 3
+                print(f"  {i+1}. {detail.filename}")
+                print(f"     Path: {detail.path}")
+                print(f"     Size: {detail.size_readable}")
+                print(f"     Directory: {detail.directory}")
+        else:
+            print("  No file details available")
+        
+        # Check if the fix worked
+        if analysis.file_count > 0:
+            print(f"\n✅ SUCCESS: File analysis is working!")
+            print(f"   - Found {analysis.file_count} files")
+            print(f"   - Development mode handling is working")
+            return True
+        else:
+            print(f"\n❌ FAILED: No files were processed")
+            return False
+            
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def main():
+    """Main test function."""
+    print("=== Testing File Size Fix ===")
+    
+    success = test_file_operations()
+    
+    if success:
+        print("\n🎉 The file size fix is working correctly!")
+        print("   Test runs should now show files even in development mode.")
+    else:
+        print("\n💥 The file size fix needs more work.")
+    
+    return 0 if success else 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Enhance test run file analysis to show 'Unknown (dev mode)' sizes for inaccessible files in development environments.

Previously, `analyze_files_for_test_mode` would completely skip files that did not exist or were inaccessible (e.g., due to missing mounts in a development environment). This resulted in test runs showing no file sizes, even when media items were correctly identified by the Plex API. This change ensures files are still listed with a clear indication of their status in development, improving the debugging experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-825d0a9e-7062-4239-86e3-1a14faf33897">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-825d0a9e-7062-4239-86e3-1a14faf33897">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

